### PR TITLE
Possibly Better Hyper-V CPU Stats

### DIFF
--- a/stats.ps1
+++ b/stats.ps1
@@ -1,37 +1,70 @@
-# I am still fighting this. I currently think Performance counters do not count in Hyper-V stats as the result of this
-# + the 4% constant Hyper-V usage from Xprotect gets me in very close to what task manager says the CPU usage is
-# If only microsoft gave me a Give-MeTheCPUUsageFromTaskManager function :|
-$proc =get-counter -Counter "\Processor(_total)\% Processor Time" -SampleInterval 2 -MaxSamples 3
-$proc = $proc | select -expand CounterSamples
-[System.Collections.ArrayList]$a = @()
+#settings
+$pwd = ConvertTo-SecureString "PASSWORD" -AsPlainText -Force
+$credz = New-Object System.Management.Automation.PSCredential("USERNAME", $pwd)
 
-Foreach ($o in $proc) {
-    $a.Add($o.CookedValue)
-} 
-$cpu = ($a | Measure-Object -Average).Average
-$cpu = [math]::Round($cpu)
+#infitie loop so data continuously gets sent to DB
+DO
+{
+    [System.Collections.ArrayList]$a = @()
+    
+    $dcollect = Get-Counter -Counter "\Hyper-V Hypervisor Logical Processor(*)\% Guest Run Time" | select -expand CounterSamples | where -property InstanceName -notmatch -Value '_total'
+    $a = @()
 
-$mem = Get-WmiObject Win32_PhysicalMemory | Measure-Object -Property Capacity -Sum
-$mem = $mem.sum
-$freemem = Get-Counter '\Memory\Available MBytes'
-$freemem = $freemem.countersamples.cookedvalue
+    Foreach ($o in $dcollect) {
+        $a.Add($o.CookedValue)
+    }
 
-$disk = Get-PSDrive C | Select-Object Used,Free
-$cused = $disk.used
-$cfree = $disk.free
+    $hvguestrun = [math]::Round(($a | Measure-Object -Average).Average)
 
-$vm = Get-VM
-$vmcount = $vm.count
-$vmrun = $vm | Where { $_.State –eq ‘Running’ }
-$vmruncount = $vmrun.count
+    $dcollect = Get-Counter -Counter "\Hyper-V Hypervisor Logical Processor(*)\% Hypervisor Run Time" | select -expand CounterSamples | where -property InstanceName -notmatch -Value '_total'
+    $a = @()
 
+    Foreach ($o in $dcollect) {
+        $a.Add($o.CookedValue)
+    }
 
-$metrics = @{cpu=$cpu;
-totalmem=$mem; 
-freemem=$freemem; 
-cfree=$cfree; 
-cused=$cused;
-vmcount=$vmcount;
-vmruncount=$vmruncount}
+    $hvhvisorrun = [math]::Round(($a | Measure-Object -Average).Average)
 
-Write-Influx -Measure Test -Tags @{Hostname=$env:COMPUTERNAME} -Metrics $metrics -Database windows-stat -Server http://10.0.6.5:8086 -Verbose
+    $dcollect = Get-Counter -Counter "\Hyper-V Hypervisor Logical Processor(*)\% Total Run Time" | select -expand CounterSamples | where -property InstanceName -notmatch -Value '_total'
+    $a = @()
+
+    Foreach ($o in $dcollect) {
+        $a.Add($o.CookedValue)
+    }
+
+    $hvtotalrun = [math]::Round(($a | Measure-Object -Average).Average)
+
+    $dcollect = Get-Counter -Counter "\Hyper-V Hypervisor Logical Processor(*)\% Idle Time" | select -expand CounterSamples | where -property InstanceName -notmatch -Value '_total'
+    $a = @()
+
+    Foreach ($o in $dcollect) {
+        $a.Add($o.CookedValue)
+    }
+
+    $hvidle = [math]::Round(($a | Measure-Object -Average).Average)
+
+    $mem = (Get-WmiObject Win32_PhysicalMemory | Measure-Object -Property Capacity -Sum).Sum
+
+    $freemem = (Get-Counter '\Memory\Available MBytes').countersamples.cookedvalue
+
+    $disk = Get-PSDrive C | Select-Object Used,Free
+    $cused = $disk.used
+    $cfree = $disk.free
+
+    $vmcount = (Get-VM).count
+    $vmruncount = (Get-VM | Where { $_.State -eq 'Running' }).count
+
+    $metrics = @{
+    totalmem=$mem; 
+    freemem=$freemem; 
+    cfree=$cfree; 
+    cused=$cused;
+    vmcount=$vmcount;
+    vmruncount=$vmruncount;
+    guestcpuruntime=$hvguestrun;
+    hypervisorcpuruntime=$hvhvisorrun;
+    totalcpuruntime=$hvtotalrun;
+    cpuidletime=$hvidle;}
+
+    Write-Influx -Measure HV -Tags @{Hostname=$env:COMPUTERNAME} -Metrics $metrics -Database DBNAME -Server http://SERVERADDRESS:8086 -Credential $credz
+} While($true)


### PR DESCRIPTION
I did some investigating and found what appear to be better Hyper-V stats, including CPU used by the Hypervisor, All Guests, Total CPU usage, and Idle CPU.

Additionally I added credentials for use with password protected InfluxDB and put it into an infinite loop so it continuously uploads new data (on my system the process uses about 0.4% CPU to run).